### PR TITLE
Support STI

### DIFF
--- a/lib/mongoid/archivable.rb
+++ b/lib/mongoid/archivable.rb
@@ -19,6 +19,9 @@ module Mongoid
 
       private
 
+      # first, try to retrieve the original_class from the stored :original_type
+      # since previous versions of this gem did not use this field, fall back 
+      # to previous method -- removing the '::Archive' from archive class name
       def original_class_name
         return self.original_type if self.respond_to?(:original_type) && self.original_type.present?
         self.class.to_s.gsub(/::Archive\z/, '')

--- a/lib/mongoid/archivable.rb
+++ b/lib/mongoid/archivable.rb
@@ -8,7 +8,7 @@ module Mongoid
     module Restoration
       # Restores the archived document to its former glory.
       def restore
-        original_document.save
+        original_document.tap(&:save)
       end
 
       def original_document

--- a/lib/mongoid/archivable.rb
+++ b/lib/mongoid/archivable.rb
@@ -16,6 +16,13 @@ module Mongoid
           doc.id = self.original_id
         end
       end
+
+      private
+
+      def original_class_name
+        return self.original_type if self.respond_to?(:original_type) && self.original_type.present?
+        self.class.to_s.gsub(/::Archive\z/, '')
+      end
     end
 
     included do

--- a/lib/mongoid/archivable.rb
+++ b/lib/mongoid/archivable.rb
@@ -8,7 +8,11 @@ module Mongoid
     module Restoration
       # Restores the archived document to its former glory.
       def restore
-        self.original_type.constantize.create(attributes.except("_id", "original_id", "original_type", "archived_at")) do |doc|
+        original_document.save
+      end
+
+      def original_document
+        self.original_type.constantize.new(attributes.except("_id", "original_id", "original_type", "archived_at")) do |doc|
           doc.id = self.original_id
         end
       end

--- a/lib/mongoid/archivable/version.rb
+++ b/lib/mongoid/archivable/version.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module Archivable
-    VERSION = "1.3.0"
+    VERSION = "1.2.0"
   end
 end

--- a/lib/mongoid/archivable/version.rb
+++ b/lib/mongoid/archivable/version.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module Archivable
-    VERSION = "1.2.0"
+    VERSION = "1.3.0"
   end
 end

--- a/spec/mongoid/archivable_spec.rb
+++ b/spec/mongoid/archivable_spec.rb
@@ -30,4 +30,9 @@ describe Mongoid::Archivable do
     expect(archive_user.original_id).to be_present
   end
 
+  it "stores the original type" do
+    user.destroy
+    expect(archive_user.original_type).to be_present
+  end
+
 end

--- a/spec/mongoid/restore_spec.rb
+++ b/spec/mongoid/restore_spec.rb
@@ -21,8 +21,17 @@ describe Mongoid::Archivable, "restore" do
     expect(User.last.id).to eq(original_id)
   end
 
-  describe "deeply nested" do
+  describe 'STI classes' do
+    let(:user) { UserSubclass.create! }
+    let(:archive_user) { UserSubclass::Archive.first }
 
+    it 'works' do
+      archive_user.restore
+      expect(UserSubclass.last.id).to eq(original_id)
+    end
+  end
+
+  describe "deeply nested" do
     let(:user) { Deeply::Nested::User.create! }
     let(:archive_user) { Deeply::Nested::User::Archive.first }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,9 @@ class User
   include Mongoid::Archivable
 end
 
+class UserSubclass < User
+end
+
 module Deeply
   module Nested
     class User


### PR DESCRIPTION
Hello there,

I made couple of adjustments to the gem, which allow for support of STI.

In the current version, the original class is inferred by removing the `::Archive` from the archive class name. That however does not apply anymore when working with STI.

This pull request stores the `original_type` and uses it when figuring out the original class. (When the `original_type` is not present – for example on documents archived with previous versions of this gem – it falls back to the former method of inferring the class.)

I have also split the `restore` method into two:
- `original_document` which returns newly instantiated document from the archive
- `restore` which saves that document

This allows to load the document from the archive and preview it (for example to the user) before actually restoring it.

I have adjusted tests and made them pass.

Thank you,
Tomas
