### PR TITLE
Support different database or client for archived documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,50 @@ User.count # => 1
 User::Archive.count # => 1
 ```
 
+## Standalone Storage
+
+By default, the archived documents will be stored in primary client and database. If you want to use different database or client for all archived documents, you can create the following middleware:
+
+```ruby
+# Rails : config/initializers/mongoid_archivable.rb
+# Ruby : config/mongoid_archivable.rb
+
+Mongoid::Archivable.configure do |config|
+  config.database = "archives"
+  config.client = "secondary"
+end
+```
+
+But if you only want to use different database or client in spesific Mongoid document, you can use this approach:
+
+```ruby
+class User
+  include Mongoid::Document
+  include Mongoid::Archive
+  archive_in database: 'achives', client: 'secondary'
+end
+```
+
+In your mongoid.yml will show like this:
+
+```yaml
+development:
+  clients:
+    default:
+      database: project_development
+      hosts:
+        - localhost:27017
+      options:
+        <<: *client_options
+    secondary:
+      database: archives
+      hosts:
+        - localhost:27018
+      options:
+        <<: *client_options
+```
+
+
 ## Development
 
 Please report any issues to the [GitHub issue tracker](https://github.com/Sign2Pay/mongoid-archivable/issues).

--- a/lib/mongoid-archivable.rb
+++ b/lib/mongoid-archivable.rb
@@ -1,3 +1,4 @@
 require 'mongoid/archivable/version'
+require 'mongoid/archivable/config'
 require 'mongoid/archivable/process_localized_fields'
 require 'mongoid/archivable'

--- a/lib/mongoid/archivable.rb
+++ b/lib/mongoid/archivable.rb
@@ -40,6 +40,17 @@ module Mongoid
       end
     end
 
+    class << self
+      def config
+        @config ||= Config.new
+        @config
+      end
+
+      def configure(&proc)
+        yield config
+      end
+    end
+
     included do
       const_set('Archive', Class.new)
       const_get('Archive').class_eval do
@@ -47,9 +58,13 @@ module Mongoid
         include Mongoid::Attributes::Dynamic
         include Mongoid::Archivable::Restoration
 
+        store_in database: ->{ Mongoid::Archivable.config.get_database }, 
+                 client: ->{ Mongoid::Archivable.config.get_client }
+
         field :archived_at, type: Time
         field :original_id, type: String
         field :original_type, type: String
+        
       end
 
       before_destroy :archive

--- a/lib/mongoid/archivable.rb
+++ b/lib/mongoid/archivable.rb
@@ -1,44 +1,13 @@
 require 'active_support/concern'
 require 'mongoid/archivable/process_localized_fields'
+require 'mongoid/archivable/restoration'
+require 'mongoid/archivable/config'
+require 'mongoid/archivable/gluten'
+require 'mongoid/archivable/depot'
 
 module Mongoid
   module Archivable
     extend ActiveSupport::Concern
-
-    module Restoration
-      # Restores the archived document to its former glory.
-      def restore
-        original_document.save
-        original_document
-      end
-
-      def original_document
-        @original_document ||= begin
-          excluded_attributes = %w(_id original_id original_type archived_at)
-          attrs = attributes.except(*excluded_attributes)
-          attrs = Mongoid::Archivable::ProcessLocalizedFields.call(original_class, attrs)
-
-          original_class.new(attrs) do |doc|
-            doc.id = original_id
-          end
-        end
-      end
-
-      # first, try to retrieve the original_class from the stored :original_type
-      # since previous versions of this gem did not use this field, fall back
-      # to previous method -- removing the '::Archive' from archive class name
-      def original_class_name
-        if respond_to?(:original_type) && original_type.present? # gem version >= 1.3.0, stored as a field.
-          original_type
-        else
-          self.class.to_s.gsub(/::Archive\z/, '') # gem version < 1.3.0, turns "User::Archive" into "User".
-        end
-      end
-
-      def original_class
-        original_class_name.constantize
-      end
-    end
 
     class << self
       def config
@@ -52,14 +21,16 @@ module Mongoid
     end
 
     included do
+      mattr_accessor :archive_storage
+      include Mongoid::Archivable::Gluten
+
       const_set('Archive', Class.new)
       const_get('Archive').class_eval do
         include Mongoid::Document
         include Mongoid::Attributes::Dynamic
         include Mongoid::Archivable::Restoration
-
-        store_in database: ->{ Mongoid::Archivable.config.get_database }, 
-                 client: ->{ Mongoid::Archivable.config.get_client }
+        include Mongoid::Archivable::Depot
+        store_in database: ->{ archive_database_name }, client: ->{ archive_client_name }
 
         field :archived_at, type: Time
         field :original_id, type: String

--- a/lib/mongoid/archivable/config.rb
+++ b/lib/mongoid/archivable/config.rb
@@ -1,0 +1,16 @@
+module Mongoid
+  module Archivable
+    class Config
+      attr_accessor :database
+      attr_accessor :client
+
+      def get_database
+        database || Mongoid::Config.clients[get_client][:database]
+      end
+
+      def get_client
+        client || :default
+      end
+    end
+  end
+end

--- a/lib/mongoid/archivable/depot.rb
+++ b/lib/mongoid/archivable/depot.rb
@@ -1,0 +1,40 @@
+module Mongoid
+  module Archivable
+    module Depot
+      extend ActiveSupport::Concern
+      included do
+        include ClassMethods
+      end
+
+      module ClassMethods
+        def has_archive_storage?
+          !parent.archive_storage.nil?
+        end
+
+        def has_archive_client?
+          has_archive_storage? && !parent.archive_storage[:client].nil?
+        end
+
+        def has_archive_database?
+          has_archive_storage? && !parent.archive_storage[:client].nil?
+        end
+
+        def archive_database_name
+          if has_archive_database?
+            parent.archive_storage[:database]
+          else
+            Mongoid::Archivable.config.get_database
+          end
+        end
+
+        def archive_client_name
+          if has_archive_client?
+            parent.archive_storage[:client]
+          else
+            Mongoid::Archivable.config.get_client
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mongoid/archivable/gluten.rb
+++ b/lib/mongoid/archivable/gluten.rb
@@ -1,0 +1,19 @@
+module Mongoid
+  module Archivable
+    module Gluten
+      extend ActiveSupport::Concern
+      included do
+        include ClassMethods
+      end
+      module ClassMethods
+        def archive_in args
+          @@archive_storage = args
+        end
+
+        def archive_storage
+          @@archive_storage
+        end
+      end
+    end
+  end
+end

--- a/lib/mongoid/archivable/restoration.rb
+++ b/lib/mongoid/archivable/restoration.rb
@@ -1,0 +1,38 @@
+module Mongoid
+  module Archivable
+    module Restoration
+      # Restores the archived document to its former glory.
+      def restore
+        original_document.save
+        original_document
+      end
+
+      def original_document
+        @original_document ||= begin
+          excluded_attributes = %w(_id original_id original_type archived_at)
+          attrs = attributes.except(*excluded_attributes)
+          attrs = Mongoid::Archivable::ProcessLocalizedFields.call(original_class, attrs)
+
+          original_class.new(attrs) do |doc|
+            doc.id = original_id
+          end
+        end
+      end
+
+      # first, try to retrieve the original_class from the stored :original_type
+      # since previous versions of this gem did not use this field, fall back
+      # to previous method -- removing the '::Archive' from archive class name
+      def original_class_name
+        if respond_to?(:original_type) && original_type.present? # gem version >= 1.3.0, stored as a field.
+          original_type
+        else
+          self.class.to_s.gsub(/::Archive\z/, '') # gem version < 1.3.0, turns "User::Archive" into "User".
+        end
+      end
+
+      def original_class
+        original_class_name.constantize
+      end
+    end
+  end
+end

--- a/spec/config/mongoid.yml
+++ b/spec/config/mongoid.yml
@@ -4,3 +4,7 @@ test:
       database: mongoid-archivable
       hosts:
         - localhost:27017
+    secondary:
+      database: archives
+      hosts:
+        - localhost:27017

--- a/spec/mongoid/archivable/archive_in.rb
+++ b/spec/mongoid/archivable/archive_in.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Mongoid::Archivable::Config do
+  let(:user) { UserTenant.create! }
+  let(:archive_user) { UserTenant::Archive.first }
+
+  before do
+    Deeply::Nested::UserTenant::Archive.destroy_all
+    UserTenant::Archive.destroy_all
+    user.destroy
+  end
+  
+  it 'uses database archives' do
+    expect(UserTenant::Archive.collection.database.name).to eq('archives')
+  end
+
+  it 'uses namespace archives.user_archives' do
+    expect(UserTenant::Archive.collection.namespace).to eq('archives.user_archives')
+  end
+
+  it 'does delete a document' do
+    expect(UserTenant.count).to be(0)
+  end
+
+  it 'allows the document to be restored' do
+    expect do
+      archive_user.restore
+    end.to change(User, :count).by(1)
+  end
+
+  describe 'deeply nested' do
+    let(:user) { Deeply::Nested::UserTenant.create! }
+    let(:archive_user) { Deeply::Nested::UserTenant::Archive.first }
+    let(:original_id) { user.id }
+
+    it 'works' do
+      archive_user.restore
+      expect(Deeply::Nested::UserTenant.last.id).to eq(original_id)
+    end
+  end
+end

--- a/spec/mongoid/archivable/config_spec.rb
+++ b/spec/mongoid/archivable/config_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe Mongoid::Archivable::Config do
+  let(:user) { User.create! }
+  let(:archive_user) { User::Archive.first }
+
+  before do
+    Mongoid::Archivable.configure do |config|
+      config.database = "archives_test"
+      config.client = "secondary"
+    end
+    Deeply::Nested::User::Archive.destroy_all
+    User::Archive.destroy_all
+    user.destroy
+  end
+  
+  it 'uses database archives_test' do
+    expect(User::Archive.collection.database.name).to eq('archives_test')
+  end
+
+  it 'uses namespace archives_test.user_archives' do
+    expect(User::Archive.collection.namespace).to eq('archives_test.user_archives')
+  end
+
+  it 'does delete a document' do
+    expect(User.count).to be(0)
+  end
+
+  it 'allows the document to be restored' do
+    expect do
+      archive_user.restore
+    end.to change(User, :count).by(1)
+  end
+
+  describe 'deeply nested' do
+    let(:user) { Deeply::Nested::User.create! }
+    let(:archive_user) { Deeply::Nested::User::Archive.first }
+    let(:original_id) { user.id }
+
+    it 'works' do
+      archive_user.restore
+      expect(Deeply::Nested::User.last.id).to eq(original_id)
+    end
+  end
+end

--- a/spec/mongoid/archivable/process_localized_fields_spec.rb
+++ b/spec/mongoid/archivable/process_localized_fields_spec.rb
@@ -5,6 +5,7 @@ describe Mongoid::Archivable::ProcessLocalizedFields, 'localized fields' do
   let(:archive_user) { User::Archive.first }
 
   before do
+    User::Archive.destroy_all
     user.destroy
   end
 

--- a/spec/mongoid/archivable_spec.rb
+++ b/spec/mongoid/archivable_spec.rb
@@ -5,8 +5,16 @@ describe Mongoid::Archivable do
     expect(Mongoid::Archivable::VERSION).not_to be nil
   end
 
+  it 'has a config' do
+    expect(defined?(Mongoid::Archivable::Config)).not_to be nil
+  end
+
   let(:user) { User.create! }
   let(:archive_user) { User::Archive.first }
+
+  before do
+    User::Archive.destroy_all
+  end
 
   it 'does delete a document' do
     user.destroy

--- a/spec/mongoid/restore_spec.rb
+++ b/spec/mongoid/restore_spec.rb
@@ -6,6 +6,8 @@ describe Mongoid::Archivable, 'restore' do
   let(:original_id) { user.id }
 
   before do
+    User::Archive.destroy_all
+    Deeply::Nested::User::Archive.destroy_all
     user.destroy
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,11 +24,25 @@ end
 class UserSubclass < User
 end
 
+class UserTenant < User
+  archive_in database: 'archives', clients: 'secondary'
+end
+
 module Deeply
   module Nested
     class User
       include Mongoid::Document
       include Mongoid::Archivable
+    end
+  end
+end
+
+module Deeply
+  module Nested
+    class UserTenant
+      include Mongoid::Document
+      include Mongoid::Archivable
+      archive_in database: 'archives', clients: 'secondary'
     end
   end
 end


### PR DESCRIPTION
Hi,

Thanks for introducing your gem to the world and I am your gem's user. I have feature which related to my product requirement and I think it will be useful for feature on next version of this gem

**PROBLEM**
The archived documents should be stored in different database or client

**SOLUTION 1**
Create initializer to setup any archive document to use database or client by configuration

```
# config/initializers/mongoid_archivable.rb
Mongoid::Archivable.configure do |config|
  config.database = "archives_test"
  config.client = "secondary"
end
```

**SOLUTION 2**

```
# config/initializers/mongoid_archivable.rb
class User
  include Mongoid::Document
  include Mongoid::Archive
  archive_in database: 'achives', client: 'secondary'
end
```

Tests and refactors are included in PR. Cheers!
