### PR TITLE
fix-process-localized-fields

### DIFF
--- a/lib/mongoid/archivable/process_localized_fields.rb
+++ b/lib/mongoid/archivable/process_localized_fields.rb
@@ -17,15 +17,16 @@ module Mongoid
 
         embedded_relations.each do |relation|
           relation_name = relation.name.to_s
-          relation_class = relation.class_name.constantize
 
           # convert embeds_many
           if attrs[relation_name].is_a?(Array)
             attrs[relation_name] = attrs[relation_name].map do |att|
+              relation_class = att.fetch('_type', relation.class_name).constantize
               ProcessLocalizedFields.call(relation_class, att)
             end
           # convert embeds_one
           elsif att = attrs[relation_name]
+            relation_class = att.fetch('_type', relation.class_name).constantize
             attrs[relation_name] = ProcessLocalizedFields.call(relation_class, att)
           end
         end


### PR DESCRIPTION
This will first attempt to infer restored class from `:_type` field (if available), and falls back to `:class_name` specified on relation itself. 

Fixes issues when restoring polymorphic embedded associations.