### PR TITLE
Call module_parent in Rails 6 and up

### DIFF
--- a/lib/mongoid/archivable/depot.rb
+++ b/lib/mongoid/archivable/depot.rb
@@ -8,20 +8,20 @@ module Mongoid
 
       module ClassMethods
         def has_archive_storage?
-          !parent.archive_storage.nil?
+          !parent_class.archive_storage.nil?
         end
 
         def has_archive_client?
-          has_archive_storage? && !parent.archive_storage[:client].nil?
+          has_archive_storage? && !parent_class.archive_storage[:client].nil?
         end
 
         def has_archive_database?
-          has_archive_storage? && !parent.archive_storage[:client].nil?
+          has_archive_storage? && !parent_class.archive_storage[:client].nil?
         end
 
         def archive_database_name
           if has_archive_database?
-            parent.archive_storage[:database]
+            parent_class.archive_storage[:database]
           else
             Mongoid::Archivable.config.get_database
           end
@@ -29,9 +29,19 @@ module Mongoid
 
         def archive_client_name
           if has_archive_client?
-            parent.archive_storage[:client]
+            parent_class.archive_storage[:client]
           else
             Mongoid::Archivable.config.get_client
+          end
+        end
+
+        private
+
+        def parent_class
+          if ActiveSupport::VERSION::MAJOR >= 6
+            model_class.module_parent
+          else
+            model_class.parent
           end
         end
       end

--- a/lib/mongoid/archivable/depot.rb
+++ b/lib/mongoid/archivable/depot.rb
@@ -39,9 +39,9 @@ module Mongoid
 
         def parent_class
           if ActiveSupport::VERSION::MAJOR >= 6
-            model_class.module_parent
+            module_parent
           else
-            model_class.parent
+            parent
           end
         end
       end


### PR DESCRIPTION
Fixes Rails 6 deprecation warning as detailed in #16.